### PR TITLE
Update google code links to github

### DIFF
--- a/templates.xml
+++ b/templates.xml
@@ -346,7 +346,7 @@
 			If you are a looking for applications to control your Z-Wave
 			devices,
 			please consult this
-			<a href="http://code.google.com/p/open-zwave/wiki/ProjectsUsingOZW">
+			<a href="https://github.com/OpenZWave/open-zwave/wiki/Projects-Using-OZW">
 				page
 			</a>
 			which lists applications that utilize OpenZWave.
@@ -359,7 +359,7 @@
 			<li>
 				Works with the multiple
 				<a
-					href="http://code.google.com/p/open-zwave/wiki/Controller_Compatibility_List">ZWave Controllers</a>
+					href="https://github.com/OpenZWave/open-zwave/wiki/Controller-Compatibility-List">ZWave Controllers</a>
 			</li>
 			<li>ZWave Protocol is abstracted away hiding a lot of the complexity</li>
 			<li>
@@ -368,7 +368,7 @@
 				etc
 				(see
 				<a
-					href="http://code.google.com/p/open-zwave/source/browse/trunk/config/manufacturer_specific.xml">here</a>
+					href="https://github.com/OpenZWave/open-zwave/blob/master/config/manufacturer_specific.xml">here</a>
 				for a complete list)
 			</li>
 			<li>Security related devices such as Locks are Supported</li>


### PR DESCRIPTION
I just updated a few dead links
I don't know if openzwave.net is still based on this repository.
